### PR TITLE
Refactor HTML parsing to use double quotes

### DIFF
--- a/aufstellung.html
+++ b/aufstellung.html
@@ -1,157 +1,139 @@
-
 <!DOCTYPE html>
 <html lang="de">
-<head>
-  <meta charset="UTF-8">
-  <title>SG Bettringen – Mannschaftsaufstellung</title>
-  <style>
+    <head>
+        <meta charset="UTF-8">
+        <title>SG Bettringen – Mannschaftsaufstellung</title>
+        <style>
     body { font-family: Arial, sans-serif; padding: 20px; background-color: #f9f9f9; }
     h1 { text-align: center; }
     table { border-collapse: collapse; width: 100%; background-color: #fff; }
     th, td { border: 1px solid #ccc; padding: 8px; text-align: center; }
     th { background-color: #e0e0e0; }
     tr:nth-child(even) { background-color: #f2f2f2; }
-  </style>
-</head>
-<body>
-  <h1>SG Bettringen – Mannschaftsaufstellung 2024/25</h1>
-  <table>
-    <tr>
-      <th>Brett</th>
-      <th>Name</th>
-      <th>DWZ</th>
-      <th>Einsätze</th>
-      <th>Brettpunkte</th>
-    </tr>
-
-    <tr>
-      <td>1</td>
-      <td>Fuchs, Martin</td>
-      <td>1887</td>
-      <td>7</td>
-      <td>4,0 : 3,0</td>
-    </tr>
-
-    <tr>
-      <td>2</td>
-      <td>Bader, Tim</td>
-      <td>1605</td>
-      <td>6</td>
-      <td>4,0 : 2,0</td>
-    </tr>
-
-    <tr>
-      <td>3</td>
-      <td>Hirning, Maxim</td>
-      <td>1554</td>
-      <td>7</td>
-      <td>5,0 : 2,0</td>
-    </tr>
-
-    <tr>
-      <td>4</td>
-      <td>Richter, Marius</td>
-      <td>1588</td>
-      <td>6</td>
-      <td>3,5 : 2,5</td>
-    </tr>
-
-    <tr>
-      <td>5</td>
-      <td>Neumeier, Erich</td>
-      <td>1632</td>
-      <td>6</td>
-      <td>3,5 : 2,5</td>
-    </tr>
-
-    <tr>
-      <td>6</td>
-      <td>Ramig, Nikita</td>
-      <td>1202</td>
-      <td>7</td>
-      <td>3,0 : 4,0</td>
-    </tr>
-
-    <tr>
-      <td>7</td>
-      <td>Wahl, Jürgen</td>
-      <td>1481</td>
-      <td>0</td>
-      <td></td>
-    </tr>
-
-    <tr>
-      <td>8</td>
-      <td>Varga, Janos</td>
-      <td></td>
-      <td>6</td>
-      <td>4,0 : 2,0</td>
-    </tr>
-
-    <tr>
-      <td>9</td>
-      <td>Plechinger, Heiko</td>
-      <td>1223</td>
-      <td>5</td>
-      <td>1,5 : 3,5</td>
-    </tr>
-
-    <tr>
-      <td>10</td>
-      <td>Schneider, Peter</td>
-      <td>1104</td>
-      <td>3</td>
-      <td>1,0 : 2,0</td>
-    </tr>
-
-    <tr>
-      <td>11</td>
-      <td>Fuchs, Anna</td>
-      <td>1281</td>
-      <td>0</td>
-      <td></td>
-    </tr>
-
-    <tr>
-      <td>12</td>
-      <td>Hoppe, Edgar</td>
-      <td>1122</td>
-      <td>1</td>
-      <td>0,0 : 1,0</td>
-    </tr>
-
-    <tr>
-      <td>13</td>
-      <td>Uzdenev, Emil</td>
-      <td>1011</td>
-      <td>0</td>
-      <td></td>
-    </tr>
-
-    <tr>
-      <td>14</td>
-      <td>Pantleon, Florian</td>
-      <td>1274</td>
-      <td>2</td>
-      <td>1,5 : 0,5</td>
-    </tr>
-
-    <tr>
-      <td>15</td>
-      <td>Malecki, Paul</td>
-      <td>1156</td>
-      <td>0</td>
-      <td></td>
-    </tr>
-
-    <tr>
-      <td>16</td>
-      <td>Köhler, Jens</td>
-      <td>1004</td>
-      <td>0</td>
-      <td></td>
-    </tr>
-
-  </table>
-</body>
+        </style>
+    </head>
+    <body>
+        <h1>SG Bettringen – Mannschaftsaufstellung 2024/25</h1>
+        <table>
+            <tr>
+                <th>Brett</th>
+                <th>Name</th>
+                <th>DWZ</th>
+                <th>Einsätze</th>
+                <th>Brettpunkte</th>
+            </tr>
+            <tr>
+                <td>1</td>
+                <td>Fuchs, Martin</td>
+                <td>1887</td>
+                <td>7</td>
+                <td>4,0 : 3,0</td>
+            </tr>
+            <tr>
+                <td>2</td>
+                <td>Bader, Tim</td>
+                <td>1605</td>
+                <td>6</td>
+                <td>4,0 : 2,0</td>
+            </tr>
+            <tr>
+                <td>3</td>
+                <td>Hirning, Maxim</td>
+                <td>1554</td>
+                <td>7</td>
+                <td>5,0 : 2,0</td>
+            </tr>
+            <tr>
+                <td>4</td>
+                <td>Richter, Marius</td>
+                <td>1588</td>
+                <td>6</td>
+                <td>3,5 : 2,5</td>
+            </tr>
+            <tr>
+                <td>5</td>
+                <td>Neumeier, Erich</td>
+                <td>1632</td>
+                <td>6</td>
+                <td>3,5 : 2,5</td>
+            </tr>
+            <tr>
+                <td>6</td>
+                <td>Ramig, Nikita</td>
+                <td>1202</td>
+                <td>7</td>
+                <td>3,0 : 4,0</td>
+            </tr>
+            <tr>
+                <td>7</td>
+                <td>Wahl, Jürgen</td>
+                <td>1481</td>
+                <td>0</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>8</td>
+                <td>Varga, Janos</td>
+                <td></td>
+                <td>6</td>
+                <td>4,0 : 2,0</td>
+            </tr>
+            <tr>
+                <td>9</td>
+                <td>Plechinger, Heiko</td>
+                <td>1223</td>
+                <td>5</td>
+                <td>1,5 : 3,5</td>
+            </tr>
+            <tr>
+                <td>10</td>
+                <td>Schneider, Peter</td>
+                <td>1104</td>
+                <td>3</td>
+                <td>1,0 : 2,0</td>
+            </tr>
+            <tr>
+                <td>11</td>
+                <td>Fuchs, Anna</td>
+                <td>1281</td>
+                <td>0</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>12</td>
+                <td>Hoppe, Edgar</td>
+                <td>1122</td>
+                <td>1</td>
+                <td>0,0 : 1,0</td>
+            </tr>
+            <tr>
+                <td>13</td>
+                <td>Uzdenev, Emil</td>
+                <td>1011</td>
+                <td>0</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>14</td>
+                <td>Pantleon, Florian</td>
+                <td>1274</td>
+                <td>2</td>
+                <td>1,5 : 0,5</td>
+            </tr>
+            <tr>
+                <td>15</td>
+                <td>Malecki, Paul</td>
+                <td>1156</td>
+                <td>0</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>16</td>
+                <td>Köhler, Jens</td>
+                <td>1004</td>
+                <td>0</td>
+                <td></td>
+            </tr>
+        </table>
+    </body>
 </html>

--- a/bettringen2.html
+++ b/bettringen2.html
@@ -1,10 +1,9 @@
-
 <!DOCTYPE html>
 <html lang="de">
-<head>
-  <meta charset="UTF-8">
-  <title>A-Klasse Schwäbisch Gmünd – Automatisch</title>
-  <style>
+    <head>
+        <meta charset="UTF-8">
+        <title>A-Klasse Schwäbisch Gmünd – Automatisch</title>
+        <style>
     body {
       font-family: Arial, sans-serif;
       padding: 20px;
@@ -29,102 +28,102 @@
     tr:nth-child(even) {
       background-color: #f2f2f2;
     }
-  </style>
-</head>
-<body>
-  <h1>A-Klasse Schwäbisch Gmünd 2024/25 – Tabelle</h1>
-  <table>
-  <tr>
-    <th>Rang</th>
-    <th>Mannschaft</th>
-    <th>1</th>
-    <th>2</th>
-    <th>3</th>
-    <th>4</th>
-    <th>5</th>
-    <th>6</th>
-    <th>Spiele</th>
-    <th>MP</th>
-    <th>BP</th>
-  </tr>
-  <tr>
-    <td>1</td>
-    <td>SU Schorndorf 4</td>
-    <td>**</td>
-    <td>3,0</td>
-    <td>3,5</td>
-    <td>4,0</td>
-    <td>5,0</td>
-    <td>5,0</td>
-    <td>5</td>
-    <td>9</td>
-    <td>20,5</td>
-  </tr>
-  <tr>
-    <td>2</td>
-    <td>SF 90 Spraitbach 6</td>
-    <td>3,0</td>
-    <td>**</td>
-    <td>3,0</td>
-    <td>6,0</td>
-    <td>5,0</td>
-    <td>6,0</td>
-    <td>5</td>
-    <td>8</td>
-    <td>23,0</td>
-  </tr>
-  <tr>
-    <td>3</td>
-    <td>SF Waldstetten 3</td>
-    <td>1,5</td>
-    <td>3,0</td>
-    <td>**</td>
-    <td>2,5</td>
-    <td>4,0</td>
-    <td>2,5</td>
-    <td>5</td>
-    <td>4</td>
-    <td>13,5</td>
-  </tr>
-  <tr>
-    <td>4</td>
-    <td>SG Schwäbisch Gmünd 6</td>
-    <td>1,0</td>
-    <td>0,0</td>
-    <td>2,5</td>
-    <td>**</td>
-    <td>3,0</td>
-    <td>4,0</td>
-    <td>5</td>
-    <td>4</td>
-    <td>10,5</td>
-  </tr>
-  <tr style="font-weight: bold; background-color: #ffeb3b;">
-    <td>5</td>
-    <td>SG Bettringen 2</td>
-    <td>1,0</td>
-    <td>1,0</td>
-    <td>2,0</td>
-    <td>3,0</td>
-    <td>**</td>
-    <td>5,0</td>
-    <td>5</td>
-    <td>3</td>
-    <td>12,0</td>
-  </tr>
-  <tr>
-    <td>6</td>
-    <td>SC Grunbach 6</td>
-    <td>1,0</td>
-    <td>0,0</td>
-    <td>3,5</td>
-    <td>2,0</td>
-    <td>1,0</td>
-    <td>**</td>
-    <td>5</td>
-    <td>2</td>
-    <td>7,5</td>
-  </tr>
-</table>
-</body>
+        </style>
+    </head>
+    <body>
+        <h1>A-Klasse Schwäbisch Gmünd 2024/25 – Tabelle</h1>
+        <table>
+            <tr>
+                <th>Rang</th>
+                <th>Mannschaft</th>
+                <th>1</th>
+                <th>2</th>
+                <th>3</th>
+                <th>4</th>
+                <th>5</th>
+                <th>6</th>
+                <th>Spiele</th>
+                <th>MP</th>
+                <th>BP</th>
+            </tr>
+            <tr>
+                <td>1</td>
+                <td>SU Schorndorf 4</td>
+                <td>**</td>
+                <td>3,0</td>
+                <td>3,5</td>
+                <td>4,0</td>
+                <td>5,0</td>
+                <td>5,0</td>
+                <td>5</td>
+                <td>9</td>
+                <td>20,5</td>
+            </tr>
+            <tr>
+                <td>2</td>
+                <td>SF 90 Spraitbach 6</td>
+                <td>3,0</td>
+                <td>**</td>
+                <td>3,0</td>
+                <td>6,0</td>
+                <td>5,0</td>
+                <td>6,0</td>
+                <td>5</td>
+                <td>8</td>
+                <td>23,0</td>
+            </tr>
+            <tr>
+                <td>3</td>
+                <td>SF Waldstetten 3</td>
+                <td>1,5</td>
+                <td>3,0</td>
+                <td>**</td>
+                <td>2,5</td>
+                <td>4,0</td>
+                <td>2,5</td>
+                <td>5</td>
+                <td>4</td>
+                <td>13,5</td>
+            </tr>
+            <tr>
+                <td>4</td>
+                <td>SG Schwäbisch Gmünd 6</td>
+                <td>1,0</td>
+                <td>0,0</td>
+                <td>2,5</td>
+                <td>**</td>
+                <td>3,0</td>
+                <td>4,0</td>
+                <td>5</td>
+                <td>4</td>
+                <td>10,5</td>
+            </tr>
+            <tr style="font-weight: bold; background-color: #ffeb3b;">
+                <td>5</td>
+                <td>SG Bettringen 2</td>
+                <td>1,0</td>
+                <td>1,0</td>
+                <td>2,0</td>
+                <td>3,0</td>
+                <td>**</td>
+                <td>5,0</td>
+                <td>5</td>
+                <td>3</td>
+                <td>12,0</td>
+            </tr>
+            <tr>
+                <td>6</td>
+                <td>SC Grunbach 6</td>
+                <td>1,0</td>
+                <td>0,0</td>
+                <td>3,5</td>
+                <td>2,0</td>
+                <td>1,0</td>
+                <td>**</td>
+                <td>5</td>
+                <td>2</td>
+                <td>7,5</td>
+            </tr>
+        </table>
+    </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="de">
-<head>
-  <meta charset="UTF-8">
-  <title>Bezirksklasse Ostalb West 2024/25 – Tabelle</title>
-  <style>
+    <head>
+        <meta charset="UTF-8">
+        <title>Bezirksklasse Ostalb West 2024/25 – Tabelle</title>
+        <style>
     body {
       font-family: Arial, sans-serif;
       padding: 20px;
@@ -32,148 +32,146 @@
       background-color: #ffeb3b;
       font-weight: bold;
     }
-  </style>
-</head>
-<body>
-  <h1>Bezirksklasse Ostalb West 2024/25 – Tabelle</h1>
-  <table>
-    <thead>
-      <tr>
-        <th>Rang</th>
-        <th>Mannschaft</th>
-        <th>1</th>
-        <th>2</th>
-        <th>3</th>
-        <th>4</th>
-        <th>5</th>
-        <th>6</th>
-        <th>7</th>
-        <th>8</th>
-        <th>Spiele</th>
-        <th>MP</th>
-        <th>BP</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>SF 90 Spraitbach 2</td>
-        <td>**</td>
-        <td>4,0</td>
-        <td>3,5</td>
-        <td>4,0</td>
-        <td>6,0</td>
-        <td>5,5</td>
-        <td>8,0</td>
-        <td>7,5</td>
-        <td>7</td>
-        <td>10</td>
-        <td>38,5</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>SF Heubach 1</td>
-        <td>4,0</td>
-        <td>**</td>
-        <td>4,5</td>
-        <td>8,0</td>
-        <td>4,0</td>
-        <td>4,0</td>
-        <td>4,0</td>
-        <td>4,0</td>
-        <td>7</td>
-        <td>9</td>
-        <td>32,5</td>
-      </tr>
-      <tr class="highlight">
-        <td>3</td>
-        <td>SG Bettringen 1</td>
-        <td>4,5</td>
-        <td>3,5</td>
-        <td>**</td>
-        <td>3,0</td>
-        <td>4,0</td>
-        <td>6,0</td>
-        <td>5,0</td>
-        <td>5,0</td>
-        <td>7</td>
-        <td>9</td>
-        <td>31,0</td>
-      </tr>
-      <tr>
-        <td>4</td>
-        <td>SG Schwäbisch Gmünd 4</td>
-        <td>4,0</td>
-        <td>0,0</td>
-        <td>5,0</td>
-        <td>**</td>
-        <td>3,5</td>
-        <td>4,0</td>
-        <td>5,5</td>
-        <td>6,5</td>
-        <td>7</td>
-        <td>8</td>
-        <td>28,5</td>
-      </tr>
-      <tr>
-        <td>5</td>
-        <td>SC Grunbach 4</td>
-        <td>2,0</td>
-        <td>4,0</td>
-        <td>4,0</td>
-        <td>4,5</td>
-        <td>**</td>
-        <td>2,5</td>
-        <td>5,0</td>
-        <td>5,0</td>
-        <td>7</td>
-        <td>8</td>
-        <td>27,0</td>
-      </tr>
-      <tr>
-        <td>6</td>
-        <td>SC Plüderhausen 2</td>
-        <td>2,5</td>
-        <td>4,0</td>
-        <td>2,0</td>
-        <td>4,0</td>
-        <td>5,5</td>
-        <td>**</td>
-        <td>3,5</td>
-        <td>5,0</td>
-        <td>7</td>
-        <td>6</td>
-        <td>26,5</td>
-      </tr>
-      <tr>
-        <td>7</td>
-        <td>SF 90 Spraitbach 4</td>
-        <td>0,0</td>
-        <td>4,0</td>
-        <td>3,0</td>
-        <td>2,5</td>
-        <td>3,0</td>
-        <td>4,5</td>
-        <td>**</td>
-        <td>5,0</td>
-        <td>7</td>
-        <td>5</td>
-        <td>22,0</td>
-      </tr>
-      <tr>
-        <td>8</td>
-        <td>SF 90 Spraitbach 3</td>
-        <td>0,5</td>
-        <td>4,0</td>
-        <td>3,0</td>
-        <td>1,5</td>
-        <td>3,0</td>
-        <td>3,0</td>
-        <td>1,0</td>
-        <td>**</td>
-        <td>7</td>
-        <td>2</td>
-        <td>16,0</td>
-      </tr>
-
- 
+        </style>
+    </head>
+    <body>
+        <h1>Bezirksklasse Ostalb West 2024/25 – Tabelle</h1>
+        <table>
+            <thead>
+                <tr>
+                    <th>Rang</th>
+                    <th>Mannschaft</th>
+                    <th>1</th>
+                    <th>2</th>
+                    <th>3</th>
+                    <th>4</th>
+                    <th>5</th>
+                    <th>6</th>
+                    <th>7</th>
+                    <th>8</th>
+                    <th>Spiele</th>
+                    <th>MP</th>
+                    <th>BP</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>1</td>
+                    <td>SF 90 Spraitbach 2</td>
+                    <td>**</td>
+                    <td>4,0</td>
+                    <td>3,5</td>
+                    <td>4,0</td>
+                    <td>6,0</td>
+                    <td>5,5</td>
+                    <td>8,0</td>
+                    <td>7,5</td>
+                    <td>7</td>
+                    <td>10</td>
+                    <td>38,5</td>
+                </tr>
+                <tr>
+                    <td>2</td>
+                    <td>SF Heubach 1</td>
+                    <td>4,0</td>
+                    <td>**</td>
+                    <td>4,5</td>
+                    <td>8,0</td>
+                    <td>4,0</td>
+                    <td>4,0</td>
+                    <td>4,0</td>
+                    <td>4,0</td>
+                    <td>7</td>
+                    <td>9</td>
+                    <td>32,5</td>
+                </tr>
+                <tr class="highlight">
+                    <td>3</td>
+                    <td>SG Bettringen 1</td>
+                    <td>4,5</td>
+                    <td>3,5</td>
+                    <td>**</td>
+                    <td>3,0</td>
+                    <td>4,0</td>
+                    <td>6,0</td>
+                    <td>5,0</td>
+                    <td>5,0</td>
+                    <td>7</td>
+                    <td>9</td>
+                    <td>31,0</td>
+                </tr>
+                <tr>
+                    <td>4</td>
+                    <td>SG Schwäbisch Gmünd 4</td>
+                    <td>4,0</td>
+                    <td>0,0</td>
+                    <td>5,0</td>
+                    <td>**</td>
+                    <td>3,5</td>
+                    <td>4,0</td>
+                    <td>5,5</td>
+                    <td>6,5</td>
+                    <td>7</td>
+                    <td>8</td>
+                    <td>28,5</td>
+                </tr>
+                <tr>
+                    <td>5</td>
+                    <td>SC Grunbach 4</td>
+                    <td>2,0</td>
+                    <td>4,0</td>
+                    <td>4,0</td>
+                    <td>4,5</td>
+                    <td>**</td>
+                    <td>2,5</td>
+                    <td>5,0</td>
+                    <td>5,0</td>
+                    <td>7</td>
+                    <td>8</td>
+                    <td>27,0</td>
+                </tr>
+                <tr>
+                    <td>6</td>
+                    <td>SC Plüderhausen 2</td>
+                    <td>2,5</td>
+                    <td>4,0</td>
+                    <td>2,0</td>
+                    <td>4,0</td>
+                    <td>5,5</td>
+                    <td>**</td>
+                    <td>3,5</td>
+                    <td>5,0</td>
+                    <td>7</td>
+                    <td>6</td>
+                    <td>26,5</td>
+                </tr>
+                <tr>
+                    <td>7</td>
+                    <td>SF 90 Spraitbach 4</td>
+                    <td>0,0</td>
+                    <td>4,0</td>
+                    <td>3,0</td>
+                    <td>2,5</td>
+                    <td>3,0</td>
+                    <td>4,5</td>
+                    <td>**</td>
+                    <td>5,0</td>
+                    <td>7</td>
+                    <td>5</td>
+                    <td>22,0</td>
+                </tr>
+                <tr>
+                    <td>8</td>
+                    <td>SF 90 Spraitbach 3</td>
+                    <td>0,5</td>
+                    <td>4,0</td>
+                    <td>3,0</td>
+                    <td>1,5</td>
+                    <td>3,0</td>
+                    <td>3,0</td>
+                    <td>1,0</td>
+                    <td>**</td>
+                    <td>7</td>
+                    <td>2</td>
+                    <td>16,0</td>
+                </tr>

--- a/update_aufstellung.py
+++ b/update_aufstellung.py
@@ -4,17 +4,15 @@ from bs4 import BeautifulSoup
 # URL zur Mannschaftsaufstellung
 url = "https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/teamPortrait?teamtable=1809461&pageState=vorrunde&championship=Ostalb+24%2F25&group=990"
 
-headers = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
-}
+headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"}
 response = requests.get(url, headers=headers)
 print(response.status_code)
 print(response.text[:1000])  # gib den Anfang des HTML aus
-response.encoding = 'utf-8'
-soup = BeautifulSoup(response.text, 'html.parser')
+response.encoding = "utf-8"
+soup = BeautifulSoup(response.text, "html.parser")
 
 # Tabelle finden
-tables = soup.find_all('table')
+tables = soup.find_all("table")
 if len(tables) < 3:
     raise Exception("❌ Nicht genügend Tabellen auf der Seite gefunden.")
 table = tables[2]
@@ -22,7 +20,7 @@ if not table:
     raise Exception("❌ Mannschaftstabelle nicht gefunden.")
 
 # Alle Zeilen holen (ohne Tabellenkopf)
-rows = table.find_all('tr')[1:]  # erste Zeile ist Kopf
+rows = table.find_all("tr")[1:]  # erste Zeile ist Kopf
 
 # HTML-Grundgerüst
 html_content = """
@@ -53,8 +51,8 @@ html_content = """
 """
 
 # Zeilen extrahieren
-for row in table.find_all('tr')[1:]:
-    cols = row.find_all('td')
+for row in table.find_all("tr")[1:]:
+    cols = row.find_all("td")
     if len(cols) >= 6:  # sicherstellen, dass genug Spalten vorhanden sind
         brett = cols[0].text.strip()
         name = cols[1].get_text(strip=True)

--- a/update_table.py
+++ b/update_table.py
@@ -4,22 +4,22 @@ from bs4 import BeautifulSoup
 # URL der nuLiga-Tabelle
 url = "https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=Ostalb+24%2F25&group=990"
 response = requests.get(url)
-response.encoding = 'utf-8'
+response.encoding = "utf-8"
 
 # HTML parsen
-soup = BeautifulSoup(response.text, 'html.parser')
+soup = BeautifulSoup(response.text, "html.parser")
 
 # Tabelle finden (erste mit class 'result' oder einfach erste große Tabelle)
-table = soup.find('table')
+table = soup.find("table")
 
 # Alle Links aus der Tabelle entfernen
-for a in table.find_all('a'):
+for a in table.find_all("a"):
     a.replace_with(a.get_text())
 
 # SG Bettringen hervorheben
-for row in table.find_all('tr'):
-    if 'SG Bettringen' in row.get_text():
-        row['style'] = 'background-color: #ffeb3b; font-weight: bold;'
+for row in table.find_all("tr"):
+    if "SG Bettringen" in row.get_text():
+        row["style"] = "background-color: #ffeb3b; font-weight: bold;"
 
 # HTML-Vorlage bauen
 html_content = f"""

--- a/update_table_2.py
+++ b/update_table_2.py
@@ -4,16 +4,16 @@ from bs4 import BeautifulSoup
 # URL zur Tabelle der 2. Mannschaft
 url = "https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=Ostalb+24%2F25&group=1181"
 response = requests.get(url)
-response.encoding = 'utf-8'
-soup = BeautifulSoup(response.text, 'html.parser')
+response.encoding = "utf-8"
+soup = BeautifulSoup(response.text, "html.parser")
 
 # Tabelle finden
-table = soup.find('table')
+table = soup.find("table")
 if not table:
     raise Exception("❌ Tabelle nicht gefunden!")
 
 # Alle Links entfernen
-for a in table.find_all('a'):
+for a in table.find_all("a"):
     a.replace_with(a.get_text())
 
 # Neue HTML-Tabelle erzeugen
@@ -36,7 +36,9 @@ for row in table.find_all("tr")[1:]:
         continue
 
     relevante_spalten = cols[1:]  # erste (leere) Spalte entfernen
-    verein_name = relevante_spalten[1].get_text(strip=True).lower()  # Spalte 1 = Mannschaft
+    verein_name = (
+        relevante_spalten[1].get_text(strip=True).lower()
+    )  # Spalte 1 = Mannschaft
 
     if "bettringen" in verein_name:
         html += '  <tr style="font-weight: bold; background-color: #ffeb3b;">\n'
@@ -95,4 +97,3 @@ with open("bettringen2.html", "w", encoding="utf-8") as f:
     f.write(html_content)
 
 print("✅ bettringen2.html erfolgreich erstellt.")
-


### PR DESCRIPTION
Updated all BeautifulSoup HTML parsing calls to use double quotes for tag names and attributes instead of single quotes. This improves consistency and readability across update_aufstellung.py, update_table.py, and update_table_2.py. Also removed a trailing blank line in update_table_2.py.